### PR TITLE
Fix "See Ad Performance" button click issue

### DIFF
--- a/scraper.py
+++ b/scraper.py
@@ -73,7 +73,7 @@ def process_ad_divs(ad_divs, ad_count, driver, dirname, ad_limit, wait=0):
         print('Ad {}'.format(ad_count))
         screenshot(ad_div, ad_count, dirname, driver)
         # Click Ad Performance
-        ad_div.find_element_by_link_text('See Ad Performance').click()
+        ad_div.find_element_by_partial_link_text('See Ad Performance').click()
         webdriver.ActionChains(driver).send_keys(Keys.ESCAPE).perform()
         processed_add_divs.add(ad_div)
         if ad_limit == ad_count:


### PR DESCRIPTION
The "See Ad Performance" button text is different on certain thumbnails, which causes the scraper to throw an error. Using `ad_div.find_element_by_partial_link_text` rather than `ad_div.find_element_by_link_text` matches either type of button.

![ad-0233](https://user-images.githubusercontent.com/12872474/45041677-e7e3f900-b036-11e8-971a-68caaae0421d.png)